### PR TITLE
Add remaining bids/medals/trophies for 2025 GA regionals

### DIFF
--- a/data/results/2025-02-01_GA_muscogee_county_regional_b.yaml
+++ b/data/results/2025-02-01_GA_muscogee_county_regional_b.yaml
@@ -6,6 +6,8 @@ Tournament:
   level: Regionals
   division: B
   year: 2025
+  medals: 4
+  trophies: 3
   bids: 4
   start date: 2025-02-01
   end date: 2025-02-01

--- a/data/results/2025-02-01_GA_shorter_university_regional_b.yaml
+++ b/data/results/2025-02-01_GA_shorter_university_regional_b.yaml
@@ -6,6 +6,8 @@ Tournament:
   level: Regionals
   division: B
   year: 2025
+  medals: 3
+  trophies: 3
   bids: 4
   start date: 2025-02-01
   end date: 2025-02-01

--- a/data/results/2025-02-08_GA_berry_regional_c.yaml
+++ b/data/results/2025-02-08_GA_berry_regional_c.yaml
@@ -7,6 +7,8 @@ Tournament:
   level: Regionals
   division: C
   year: 2025
+  medals: 3
+  trophies: 3
   bids: 4
   start date: 2025-02-08
   end date: 2025-02-08

--- a/data/results/2025-02-08_GA_oglethorpe_regional_b.yaml
+++ b/data/results/2025-02-08_GA_oglethorpe_regional_b.yaml
@@ -7,6 +7,8 @@ Tournament:
   level: Regionals
   division: B
   year: 2025
+  medals: 4
+  trophies: 3
   bids: 4
   start date: 2025-02-08
   end date: 2025-02-08

--- a/data/results/2025-02-08_GA_ung_gainesville_regional_c.yaml
+++ b/data/results/2025-02-08_GA_ung_gainesville_regional_c.yaml
@@ -7,6 +7,9 @@ Tournament:
   level: Regionals
   division: C
   year: 2025
+  medals: 4
+  trophies: 3
+  bids: 4
   start date: 2025-02-08
   end date: 2025-02-08
   awards date: 2025-02-08

--- a/data/results/2025-02-15_GA_augusta_regional_c.yaml
+++ b/data/results/2025-02-15_GA_augusta_regional_c.yaml
@@ -7,6 +7,8 @@ Tournament:
   level: Regionals
   division: C
   year: 2025
+  medals: 3
+  trophies: 3
   bids: 3
   start date: 2025-02-15
   end date: 2025-02-15

--- a/data/results/2025-02-15_GA_bulloch_county_regional_b.yaml
+++ b/data/results/2025-02-15_GA_bulloch_county_regional_b.yaml
@@ -7,6 +7,8 @@ Tournament:
   level: Regionals
   division: B
   year: 2025
+  medals: 3
+  trophies: 3
   bids: 3
   n offset: -3
   start date: 2025-02-15

--- a/data/results/2025-02-15_GA_mgsu_regional_c.yaml
+++ b/data/results/2025-02-15_GA_mgsu_regional_c.yaml
@@ -7,6 +7,9 @@ Tournament:
   level: Regionals
   division: C
   year: 2025
+  medals: 5
+  trophies: 4
+  bids: 4
   start date: 2025-02-15
   end date: 2025-02-15
   awards date: 2025-02-15

--- a/data/results/2025-02-22_GA_emory_regional_b.yaml
+++ b/data/results/2025-02-22_GA_emory_regional_b.yaml
@@ -7,6 +7,8 @@ Tournament:
   level: Regionals
   division: B
   year: 2025
+  medals: 3
+  trophies: 3
   bids: 2
   start date: 2025-02-22
   end date: 2025-02-22

--- a/data/results/2025-02-22_GA_georgia_state_regional_b.yaml
+++ b/data/results/2025-02-22_GA_georgia_state_regional_b.yaml
@@ -7,6 +7,8 @@ Tournament:
   level: Regionals
   division: B
   year: 2025
+  medals: 5
+  trophies: 4
   bids: 5
   n offset: -5
   start date: 2025-02-22

--- a/data/results/2025-02-22_GA_ung_dahlonega_regional_c.yaml
+++ b/data/results/2025-02-22_GA_ung_dahlonega_regional_c.yaml
@@ -7,6 +7,8 @@ Tournament:
   level: Regionals
   division: C
   year: 2025
+  medals: 4
+  trophies: 3
   bids: 4
   start date: 2025-02-22
   end date: 2025-02-22

--- a/data/results/2025-03-01_GA_georgia_southern_regional_c.yaml
+++ b/data/results/2025-03-01_GA_georgia_southern_regional_c.yaml
@@ -7,6 +7,9 @@ Tournament:
   level: Regionals
   division: C
   year: 2025
+  medals: 4
+  trophies: 3
+  bids: 1
   n offset: -1
   start date: 2025-03-01
   end date: 2025-03-01

--- a/data/results/2025-03-01_GA_northeast_georgia_regional_b.yaml
+++ b/data/results/2025-03-01_GA_northeast_georgia_regional_b.yaml
@@ -7,6 +7,8 @@ Tournament:
   level: Regionals
   division: B
   year: 2025
+  medals: 4
+  trophies: 3
   bids: 6
   start date: 2025-03-01
   end date: 2025-03-01

--- a/data/results/2025-03-08_GA_gsu_perimeter_clarkston_regional_c.yaml
+++ b/data/results/2025-03-08_GA_gsu_perimeter_clarkston_regional_c.yaml
@@ -9,6 +9,7 @@ Tournament:
   year: 2025
   medals: 5
   trophies: 5
+  bids: 6
   start date: 2025-03-08
   end date: 2025-03-08
   awards date: 2025-03-08


### PR DESCRIPTION
Notes:
* Affects the 7 B and 7 C regionals in GA for 2025.
* The Class AA vs. A bids in Div C are not currently supported by Duosmium. In keeping with the prior handling in some of this data, I've included a `bids` field with the number of Class AA bids, with intention to re-add with all the Class A bids someday if/when arbitrary bid assignments or similar such handling becomes possible.