### PR TITLE
Convert GA C Regional bids to new array-based format

### DIFF
--- a/data/results/2024-02-10_GA_ung_gainesville_regional_c.yaml
+++ b/data/results/2024-02-10_GA_ung_gainesville_regional_c.yaml
@@ -9,6 +9,7 @@ Tournament:
   year: 2024
   medals: 4
   trophies: 3
+  bids: [10, 13, 8, 4]
   start date: 2024-02-10
   end date: 2024-02-10
   awards date: 2024-02-10

--- a/data/results/2024-02-17_GA_ksu_marietta_regional_c.yaml
+++ b/data/results/2024-02-17_GA_ksu_marietta_regional_c.yaml
@@ -9,7 +9,7 @@ Tournament:
   year: 2024
   medals: 5
   trophies: 4
-  bids: [16, 6, 23, 14, 3, 11]
+  bids: 6
   start date: 2024-02-17
   end date: 2024-02-17
   awards date: 2024-02-17

--- a/data/results/2024-02-17_GA_ksu_marietta_regional_c.yaml
+++ b/data/results/2024-02-17_GA_ksu_marietta_regional_c.yaml
@@ -9,6 +9,7 @@ Tournament:
   year: 2024
   medals: 5
   trophies: 4
+  bids: [16, 6, 23, 14, 3, 11]
   start date: 2024-02-17
   end date: 2024-02-17
   awards date: 2024-02-17

--- a/data/results/2024-02-17_GA_mgsu_regional_c.yaml
+++ b/data/results/2024-02-17_GA_mgsu_regional_c.yaml
@@ -9,6 +9,7 @@ Tournament:
   year: 2024
   medals: 5
   trophies: 3
+  bids: [9, 11, 15, 5, 14, 13]
   start date: 2024-02-17
   end date: 2024-02-17
   awards date: 2024-02-17

--- a/data/results/2024-02-24_GA_georgia_southern_regional_c.yaml
+++ b/data/results/2024-02-24_GA_georgia_southern_regional_c.yaml
@@ -9,6 +9,7 @@ Tournament:
   year: 2024
   medals: 4
   trophies: 3
+  bids: [5, 8, 13, 15, 7]
   start date: 2024-02-24
   end date: 2024-02-24
   awards date: 2024-02-24

--- a/data/results/2024-03-02_GA_gsu_perimeter_clarkston_regional_c.yaml
+++ b/data/results/2024-03-02_GA_gsu_perimeter_clarkston_regional_c.yaml
@@ -9,6 +9,7 @@ Tournament:
   year: 2024
   medals: 5
   trophies: 5
+  bids: [6, 13, 20, 24, 1, 15, 18, 5, 36, 31]
   n offset: -2
   start date: 2024-03-02
   end date: 2024-03-02

--- a/data/results/2024-03-02_GA_ung_dahlonega_regional_c.yaml
+++ b/data/results/2024-03-02_GA_ung_dahlonega_regional_c.yaml
@@ -9,6 +9,7 @@ Tournament:
   year: 2024
   medals: 4
   trophies: 3
+  bids: [13, 1, 7, 5, 12]
   start date: 2024-03-02
   end date: 2024-03-02
   awards date: 2024-03-02

--- a/data/results/2025-02-08_GA_berry_regional_c.yaml
+++ b/data/results/2025-02-08_GA_berry_regional_c.yaml
@@ -9,7 +9,7 @@ Tournament:
   year: 2025
   medals: 3
   trophies: 3
-  bids: 4
+  bids: [10, 4, 7, 2]
   start date: 2025-02-08
   end date: 2025-02-08
   awards date: 2025-02-08

--- a/data/results/2025-02-08_GA_ung_gainesville_regional_c.yaml
+++ b/data/results/2025-02-08_GA_ung_gainesville_regional_c.yaml
@@ -9,7 +9,7 @@ Tournament:
   year: 2025
   medals: 4
   trophies: 3
-  bids: 4
+  bids: [15, 6, 4, 1, 10]
   start date: 2025-02-08
   end date: 2025-02-08
   awards date: 2025-02-08

--- a/data/results/2025-02-15_GA_augusta_regional_c.yaml
+++ b/data/results/2025-02-15_GA_augusta_regional_c.yaml
@@ -9,7 +9,7 @@ Tournament:
   year: 2025
   medals: 3
   trophies: 3
-  bids: 3
+  bids: [4, 7, 2]
   start date: 2025-02-15
   end date: 2025-02-15
   awards date: 2025-02-15

--- a/data/results/2025-02-15_GA_mgsu_regional_c.yaml
+++ b/data/results/2025-02-15_GA_mgsu_regional_c.yaml
@@ -9,7 +9,7 @@ Tournament:
   year: 2025
   medals: 5
   trophies: 4
-  bids: 4
+  bids: [4, 13, 17, 7, 15, 2, 9, 19]
   start date: 2025-02-15
   end date: 2025-02-15
   awards date: 2025-02-15

--- a/data/results/2025-02-22_GA_ung_dahlonega_regional_c.yaml
+++ b/data/results/2025-02-22_GA_ung_dahlonega_regional_c.yaml
@@ -9,7 +9,7 @@ Tournament:
   year: 2025
   medals: 4
   trophies: 3
-  bids: [9, 6, 16, 18]
+  bids: 4
   start date: 2025-02-22
   end date: 2025-02-22
   awards date: 2025-02-22

--- a/data/results/2025-02-22_GA_ung_dahlonega_regional_c.yaml
+++ b/data/results/2025-02-22_GA_ung_dahlonega_regional_c.yaml
@@ -9,7 +9,7 @@ Tournament:
   year: 2025
   medals: 4
   trophies: 3
-  bids: 4
+  bids: [9, 6, 16, 18]
   start date: 2025-02-22
   end date: 2025-02-22
   awards date: 2025-02-22

--- a/data/results/2025-03-01_GA_georgia_southern_regional_c.yaml
+++ b/data/results/2025-03-01_GA_georgia_southern_regional_c.yaml
@@ -9,7 +9,7 @@ Tournament:
   year: 2025
   medals: 4
   trophies: 3
-  bids: 1
+  bids: [11, 16, 9, 7]
   n offset: -1
   start date: 2025-03-01
   end date: 2025-03-01

--- a/data/results/2025-03-08_GA_gsu_perimeter_clarkston_regional_c.yaml
+++ b/data/results/2025-03-08_GA_gsu_perimeter_clarkston_regional_c.yaml
@@ -9,7 +9,7 @@ Tournament:
   year: 2025
   medals: 5
   trophies: 5
-  bids: 6
+  bids: [33, 5, 11, 21, 17, 1, 15, 4, 14]
   start date: 2025-03-08
   end date: 2025-03-08
   awards date: 2025-03-08


### PR DESCRIPTION
Convert 2024 and 2025 GA C Regional bids to the new array-based format, to correctly handle AA vs. A track bids

Reference:
* `https://scioly.org/wiki/index.php/2024_Georgia_State_Tournament`
* `https://scioly.org/wiki/index.php/2025_Georgia_State_Tournament`