### PR TITLE
Update bids for 2026 GA Regionals

### DIFF
--- a/data/results/2026-02-07_GA_muscogee_county_regional_b.yaml
+++ b/data/results/2026-02-07_GA_muscogee_county_regional_b.yaml
@@ -7,6 +7,7 @@ Tournament:
   division: B
   year: 2026
   n offset: -1
+  bids: [1, 7, 11, 3, 2]
   start date: 2026-02-07
   end date: 2026-02-07
   awards date: 2026-02-07

--- a/data/results/2026-02-07_GA_oglethorpe_regional_b.yaml
+++ b/data/results/2026-02-07_GA_oglethorpe_regional_b.yaml
@@ -6,6 +6,7 @@ Tournament:
   level: Regionals
   division: B
   year: 2026
+  bids: [9, 6, 4, 14, 1]
   start date: 2026-02-07
   end date: 2026-02-07
   awards date: 2026-02-07

--- a/data/results/2026-02-07_GA_shorter_regional_b.yaml
+++ b/data/results/2026-02-07_GA_shorter_regional_b.yaml
@@ -7,6 +7,7 @@ Tournament:
   division: B
   year: 2026
   n offset: -2
+  bids: [3, 6, 13, 12, 2]
   start date: 2026-02-07
   end date: 2026-02-07
   awards date: 2026-02-07

--- a/data/results/2026-02-07_GA_uga_regional_c.yaml
+++ b/data/results/2026-02-07_GA_uga_regional_c.yaml
@@ -6,6 +6,7 @@ Tournament:
   level: Regionals
   division: C
   year: 2026
+  bids: [22, 4, 14, 10, 2, 15]
   start date: 2026-02-07
   end date: 2026-02-07
   awards date: 2026-02-07

--- a/data/results/2026-02-07_GA_ung_gainesville_regional_c.yaml
+++ b/data/results/2026-02-07_GA_ung_gainesville_regional_c.yaml
@@ -8,7 +8,7 @@ Tournament:
   year: 2026
   medals: 5
   trophies: 3
-  bids: [10, 14, 3, 18, 9]
+  bids: [10, 14, 3, 18]
   start date: 2026-02-07
   end date: 2026-02-07
   awards date: 2026-02-07

--- a/data/results/2026-02-14_GA_emory_regional_b.yaml
+++ b/data/results/2026-02-14_GA_emory_regional_b.yaml
@@ -6,6 +6,7 @@ Tournament:
   level: Regionals
   division: B
   year: 2026
+  bids: [2, 10, 9]
   start date: 2026-02-14
   end date: 2026-02-14
   awards date: 2026-02-14

--- a/data/results/2026-02-21_GA_berry_regional_c.yaml
+++ b/data/results/2026-02-21_GA_berry_regional_c.yaml
@@ -6,6 +6,7 @@ Tournament:
   level: Regionals
   division: C
   year: 2026
+  bids: [16, 17, 1, 5, 8, 7, 3]
   start date: 2026-02-21
   end date: 2026-02-21
   awards date: 2026-02-21

--- a/data/results/2026-02-21_GA_bulloch_county_regional_b.yaml
+++ b/data/results/2026-02-21_GA_bulloch_county_regional_b.yaml
@@ -6,6 +6,7 @@ Tournament:
   level: Regionals
   division: B
   year: 2026
+  bids: [4, 6, 9, 8]
   start date: 2026-02-21
   end date: 2026-02-21
   awards date: 2026-02-21

--- a/data/results/2026-02-21_GA_gsu_dunwoody_regional_c.yaml
+++ b/data/results/2026-02-21_GA_gsu_dunwoody_regional_c.yaml
@@ -8,6 +8,7 @@ Tournament:
   year: 2026
   medals: 5
   trophies: 4
+  bids: [15, 3, 9, 20, 12, 1]
   start date: 2026-02-21
   end date: 2026-02-21
   awards date: 2026-02-21

--- a/data/results/2026-02-21_GA_mgsu_regional_c.yaml
+++ b/data/results/2026-02-21_GA_mgsu_regional_c.yaml
@@ -6,6 +6,7 @@ Tournament:
   level: Regionals
   division: C
   year: 2026
+  bids: [5, 20, 16, 9, 13, 2, 12]
   start date: 2026-02-21
   end date: 2026-02-21
   awards date: 2026-02-21

--- a/data/results/2026-02-21_GA_northeast_georgia_regional_b.yaml
+++ b/data/results/2026-02-21_GA_northeast_georgia_regional_b.yaml
@@ -6,6 +6,7 @@ Tournament:
   level: Regionals
   division: B
   year: 2026
+  bids: [9, 11, 6, 17]
   start date: 2026-02-21
   end date: 2026-02-21
   awards date: 2026-02-21

--- a/data/results/2026-02-28_GA_georgia_southern_regional_c.yaml
+++ b/data/results/2026-02-28_GA_georgia_southern_regional_c.yaml
@@ -6,6 +6,7 @@ Tournament:
   level: Regionals
   division: C
   year: 2026
+  bids: [12, 19, 17, 20, 3]
   start date: 2026-02-28
   end date: 2026-02-28
   awards date: 2026-02-28

--- a/data/results/2026-02-28_GA_gsu_regional_b.yaml
+++ b/data/results/2026-02-28_GA_gsu_regional_b.yaml
@@ -6,6 +6,7 @@ Tournament:
   level: Regionals
   division: B
   year: 2026
+  bids: [1, 19, 13, 8, 17, 7]
   start date: 2026-02-28
   end date: 2026-02-28
   awards date: 2026-02-28

--- a/data/results/2026-02-28_GA_ung_dahlonega_regional_c.yaml
+++ b/data/results/2026-02-28_GA_ung_dahlonega_regional_c.yaml
@@ -6,6 +6,7 @@ Tournament:
   level: Regionals
   division: C
   year: 2026
+  bids: [18, 7, 11, 4, 9]
   start date: 2026-02-28
   end date: 2026-02-28
   awards date: 2026-02-28


### PR DESCRIPTION
Sourced from [here](https://www.instagram.com/georgiascioly/p/DVeKklyiZBG/), alternatively viewable [here](https://scioly.org/wiki/Georgia#State_Qualifying_Teams). Provided in set format to account for the two-track bid system.