### PR TITLE
Various medal/trophy count updates for 2014-2020 competitions

### DIFF
--- a/data/results/2014-03-14_NY_states_c.yaml
+++ b/data/results/2014-03-14_NY_states_c.yaml
@@ -4,8 +4,8 @@ Tournament:
   level: States
   division: C
   year: 2014
-  medals: 3
-  trophies: 9
+  medals: 10
+  trophies: 6
   bids: 2
   start date: 2014-03-14
   end date: 2014-03-15

--- a/data/results/2014-04-04_NY_states_b.yaml
+++ b/data/results/2014-04-04_NY_states_b.yaml
@@ -4,8 +4,8 @@ Tournament:
   level: States
   division: B
   year: 2014
-  medals: 3
-  trophies: 9
+  medals: 6
+  trophies: 6
   bids: 2
   start date: 2014-04-04
   end date: 2014-04-05

--- a/data/results/2015-03-13_NY_states_c.yaml
+++ b/data/results/2015-03-13_NY_states_c.yaml
@@ -5,7 +5,7 @@ Tournament:
   division: C
   year: 2015
   medals: 10
-  trophies: 10
+  trophies: 6
   bids: 2
   start date: 2015-03-13
   end date: 2015-03-14

--- a/data/results/2015-04-17_NY_states_b.yaml
+++ b/data/results/2015-04-17_NY_states_b.yaml
@@ -4,8 +4,8 @@ Tournament:
   level: States
   division: B
   year: 2015
-  medals: 10
-  trophies: 10
+  medals: 6
+  trophies: 6
   bids: 2
   start date: 2015-04-17
   end date: 2015-04-18

--- a/data/results/2016-03-11_NY_states_c.yaml
+++ b/data/results/2016-03-11_NY_states_c.yaml
@@ -6,6 +6,8 @@ Tournament:
   level: States
   division: C
   year: 2016
+  medals: 10
+  trophies: 6
   bids: 2
   start date: 2016-03-11
   end date: 2016-03-12

--- a/data/results/2016-04-08_NY_states_b.yaml
+++ b/data/results/2016-04-08_NY_states_b.yaml
@@ -6,6 +6,8 @@ Tournament:
   level: States
   division: B
   year: 2016
+  medals: 6
+  trophies: 6
   bids: 2
   start date: 2016-04-08
   end date: 2016-04-09

--- a/data/results/2017-02-11_tiger_invitational_c.yaml
+++ b/data/results/2017-02-11_tiger_invitational_c.yaml
@@ -6,6 +6,8 @@ Tournament:
   level: Invitational
   division: C
   year: 2017
+  medals: 5
+  trophies: 5
   start date: 2017-02-11
   end date: 2017-02-11
   awards date: 2017-02-11

--- a/data/results/2018-01-27_yale_invitational_c.yaml
+++ b/data/results/2018-01-27_yale_invitational_c.yaml
@@ -6,7 +6,7 @@ Tournament:
   level: Invitational
   division: C
   year: 2018
-  medals: 6
+  medals: 5
   trophies: 6
   start date: 2018-01-27
   end date: 2018-01-27

--- a/data/results/2018-02-10_tiger_invitational_c.yaml
+++ b/data/results/2018-02-10_tiger_invitational_c.yaml
@@ -6,6 +6,7 @@ Tournament:
   level: Invitational
   division: C
   year: 2018
+  medals: 5
   n offset: -4
   start date: 2018-02-10
   end date: 2018-02-10

--- a/data/results/2018-02-17_cornell_invitational_b.yaml
+++ b/data/results/2018-02-17_cornell_invitational_b.yaml
@@ -7,7 +7,7 @@ Tournament:
   division: B
   year: 2018
   medals: 6
-  trophies: 6
+  trophies: 8
   date: 2018-02-17
 Events:
 - name: Anatomy and Physiology

--- a/data/results/2018-02-17_cornell_invitational_b.yaml
+++ b/data/results/2018-02-17_cornell_invitational_b.yaml
@@ -6,6 +6,8 @@ Tournament:
   level: Invitational
   division: B
   year: 2018
+  medals: 6
+  trophies: 6
   date: 2018-02-17
 Events:
 - name: Anatomy and Physiology

--- a/data/results/2018-02-17_cornell_invitational_c.yaml
+++ b/data/results/2018-02-17_cornell_invitational_c.yaml
@@ -6,6 +6,8 @@ Tournament:
   level: Invitational
   division: C
   year: 2018
+  medals: 6
+  trophies: 6
   date: 2018-02-17
 Events:
 - name: Anatomy and Physiology

--- a/data/results/2018-02-17_cornell_invitational_c.yaml
+++ b/data/results/2018-02-17_cornell_invitational_c.yaml
@@ -7,7 +7,7 @@ Tournament:
   division: C
   year: 2018
   medals: 6
-  trophies: 6
+  trophies: 8
   date: 2018-02-17
 Events:
 - name: Anatomy and Physiology

--- a/data/results/2019-01-05_capital_region_invitational_c.yaml
+++ b/data/results/2019-01-05_capital_region_invitational_c.yaml
@@ -6,6 +6,8 @@ Tournament:
   level: Invitational
   division: C
   year: 2019
+  medals: 6
+  trophies: 6
   date: 2019-01-05
 Events:
 - name: Anatomy and Physiology

--- a/data/results/2019-01-26_yale_invitational_c.yaml
+++ b/data/results/2019-01-26_yale_invitational_c.yaml
@@ -6,7 +6,7 @@ Tournament:
   level: Invitational
   division: C
   year: 2019
-  medals: 6
+  medals: 5
   trophies: 6
   start date: 2019-01-26
   end date: 2019-01-26

--- a/data/results/2019-02-09_tiger_invitational_c.yaml
+++ b/data/results/2019-02-09_tiger_invitational_c.yaml
@@ -6,6 +6,7 @@ Tournament:
   level: Invitational
   division: C
   year: 2019
+  medals: 5
   n offset: -4
   start date: 2019-02-09
   end date: 2019-02-09

--- a/data/results/2019-11-23_cornell_invitational_c.yaml
+++ b/data/results/2019-11-23_cornell_invitational_c.yaml
@@ -8,6 +8,7 @@ Tournament:
   year: 2020
   date: 2019-11-23
   medals: 6
+  trophies: 6
 Events:
 - name: Anatomy and Physiology
 - name: Astronomy

--- a/data/results/2020-01-04_capital_region_invitational_c.yaml
+++ b/data/results/2020-01-04_capital_region_invitational_c.yaml
@@ -6,6 +6,8 @@ Tournament:
   level: Invitational
   division: C
   year: 2020
+  medals: 6
+  trophies: 6
   date: 2020-01-04
 Events:
 - name: Anatomy and Physiology

--- a/data/results/2020-01-25_north_pocono_invitational_c.yaml
+++ b/data/results/2020-01-25_north_pocono_invitational_c.yaml
@@ -6,6 +6,8 @@ Tournament:
   level: Invitational
   division: C
   year: 2020
+  medals: 7
+  trophies: 6
   date: 2020-01-25
 Events:
 - name: Anatomy and Physiology

--- a/data/results/2020-02-08_centerville_invitational_c.yaml
+++ b/data/results/2020-02-08_centerville_invitational_c.yaml
@@ -7,6 +7,8 @@ Tournament:
   level: Invitational
   division: C
   year: 2020
+  medals: 8
+  trophies: 8
   date: 2020-02-08
 Events:
 - name: Anatomy and Physiology


### PR DESCRIPTION
This changes medal and/or trophy counts for the following competitions (all of which I was at/have school results from to confirm this)

-2020 Centerville C Invitational
-2020 North Pocono Invitational
-2020 Capital Region Invitational
-2020 Cornell Invitational
-2019 Tiger Invitational
-2019 Yale Invitational
-2019 Capital Region Invitational
-2018 Cornell Invitational C
-2018 Cornell Invitational B
-2018 Tiger Invitational
-2018 Yale Invitational
-2017 Tiger Invitational
-2016 NY B
-2016 NY C
-2015 NY B
-2015 NY C
-2014 NY B
-2014 NY C
